### PR TITLE
Standarize beacon port

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -34,7 +34,7 @@ ENV JAVA_OPTS="-Xmx4g"
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 
 # API port: https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#rest-api-port
-EXPOSE 5001
+EXPOSE $BEACON_API_PORT
 # P2P port: https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#p2p-port
 EXPOSE 9000
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -78,7 +78,7 @@ if [ ! -z "${PUBLIC_KEYS_PARSED}" ]; then
     --validators-external-signer-url=$HTTP_WEB3SIGNER \
     --validators-external-signer-public-keys=$PUBLIC_KEYS_PARSED \
     --p2p-port=9000 \
-    --rest-api-cors-origins=* \
+    --rest-api-cors-origins="*" \
     --rest-api-interface=0.0.0.0 \
     --rest-api-port=$BEACON_API_PORT \
     --rest-api-host-allowlist=* \
@@ -98,7 +98,7 @@ else
     #--validators-external-signer-url=$HTTP_WEB3SIGNER \
     #--validators-external-signer-public-keys=$PUBLIC_KEYS_PARSED \
     --p2p-port=9000 \
-    --rest-api-cors-origins=* \
+    --rest-api-cors-origins="*" \
     --rest-api-interface=0.0.0.0 \
     --rest-api-port=$BEACON_API_PORT \
     --rest-api-host-allowlist=* \

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -80,7 +80,7 @@ if [ ! -z "${PUBLIC_KEYS_PARSED}" ]; then
     --p2p-port=9000 \
     --rest-api-cors-origins=* \
     --rest-api-interface=0.0.0.0 \
-    --rest-api-port=5051 \
+    --rest-api-port=$BEACON_API_PORT \
     --rest-api-host-allowlist=* \
     --rest-api-enabled=true \
     --rest-api-docs-enabled=true \
@@ -100,7 +100,7 @@ else
     --p2p-port=9000 \
     --rest-api-cors-origins=* \
     --rest-api-interface=0.0.0.0 \
-    --rest-api-port=5051 \
+    --rest-api-port=$BEACON_API_PORT \
     --rest-api-host-allowlist=* \
     --rest-api-enabled=true \
     --rest-api-docs-enabled=true \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: ./build
       args:
+        BEACON_API_PORT: 3500"
         UPSTREAM_VERSION: 22.1.1
     user: root
     image: "teku.teku-prater.dnp.dappnode.eth:0.1.0"
@@ -11,6 +12,7 @@ services:
       - "teku-prater-data:/opt/teku/data"
       - "teku-public-keys:/opt/teku/public-keys"
     environment:
+      BEACON_API_PORT: "3500"
       HTTP_WEB3PROVIDER: "http://goerli-geth.dappnode:8545"
       HTTP_WEB3SIGNER: "http://web3signer.web3signer-prater.dappnode:9000"
       PUBLIC_KEYS_FILE: /opt/teku/public-keys/public_keys.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./build
       args:
-        BEACON_API_PORT: 3500"
+        BEACON_API_PORT: 3500
         UPSTREAM_VERSION: 22.1.1
     user: root
     image: "teku.teku-prater.dnp.dappnode.eth:0.1.0"
@@ -12,7 +12,7 @@ services:
       - "teku-prater-data:/opt/teku/data"
       - "teku-public-keys:/opt/teku/public-keys"
     environment:
-      BEACON_API_PORT: "3500"
+      BEACON_API_PORT: "3500" # Do not change! standard port 3500 for beacon api
       HTTP_WEB3PROVIDER: "http://goerli-geth.dappnode:8545"
       HTTP_WEB3SIGNER: "http://web3signer.web3signer-prater.dappnode:9000"
       PUBLIC_KEYS_FILE: /opt/teku/public-keys/public_keys.txt


### PR DESCRIPTION
standarize beacon API port to 3500. Used by the dappmanager to get sync status