### PR TITLE
Implement fee recipient address

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -27,3 +27,14 @@ fields:
       To get Teku up and running in only a few minutes, you can start Teku from a recent finalized checkpoint state rather than syncing from genesis. This is substantially **faster** and consumes **less resources** than syncing from genesis, while still providing all the same features. Be sure you are using a trusted node for the fast sync. Check [Teku docs](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Checkpoint-Start/)
       Get your checkpoint sync from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-prater.infura.io)
     required: false
+  - id: feeRecipientAddress
+    target:
+      type: environment
+      name: FEE_RECIPIENT_ADDRESS
+      service: validator
+    title: Fee Recipient Address
+    description: >-
+      Fee Recipient is a feature that lets you specify a priority fee recipient address on your validator client instance and beacon node. After The Merge, execution clients will begin depositing priority fees into this address whenever your validator client proposes a new block.
+    required: true
+    pattern: "^0x[a-fA-F0-9]{40}$"
+    patternErrorMessage: Must be a valid address (0x1fd16a...)

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -40,5 +40,6 @@ exec /opt/teku/bin/teku --log-destination=CONSOLE \
   --validators-graffiti=\"${GRAFFITI}\" \
   --validator-api-keystore-file=/cert/teku_client_keystore.p12 \
   --validator-api-keystore-password-file=/cert/teku_keystore_password.txt \
+  --validators-proposer-default-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \
   --logging=ALL \
   ${EXTRA_OPTS}


### PR DESCRIPTION
Implement fee recipient address during installation through the setup-wizard

For consistency, this value should be set in both services: beacon-chain and validator. See https://github.com/dappnode/DAppNodeSDK/issues/238