### PR TITLE
Add exit option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "9505:9505/tcp"
       - "9505:9505/udp"
     restart: unless-stopped
-    image: "beacon-chain.teku-prater.dnp.dappnode.eth:0.1.0"
+    image: "beacon-chain.teku-prater.dnp.dappnode.eth:0.1.11"
   validator:
     build:
       context: ./validator
@@ -28,8 +28,10 @@ services:
       BEACON_NODE_ADDR: "http://beacon-chain.teku-prater.dappnode:3500"
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
+      EXIT_VALIDATOR: ""
+      KEYSTORES_VOLUNTARY_EXIT: ""
       FEE_RECIPIENT_ADDRESS: ""
     restart: unless-stopped
-    image: "validator.teku-prater.dnp.dappnode.eth:0.1.0"
+    image: "validator.teku-prater.dnp.dappnode.eth:0.1.11"
 volumes:
   teku-prater-data: {}

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -16,6 +16,18 @@ if [ -n "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" ] && [ "$_DAPPNODE_GLOBAL_MEVBOOST_P
   fi
 fi
 
+
+
+if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]];
+then
+    echo "Proceeds to do the voluntary exit of the next keystores:"
+    echo "$KEYSTORES_VOLUNTARY_EXIT"
+    exec/opt/teku/bin/teku voluntary-exit --beacon-node-api-endpoint=http://beacon-chain.teku-prater.dappnode:3500 \
+        --validators-external-signer-public-keys=$KEYSTORES_VOLUNTARY_EXIT \
+        --validators-external-signer-url=http://web3signer.web3signer-prater.dappnode:9000
+fi
+
+
 # Teku must start with the current env due to JAVA_HOME var
 exec /opt/teku/bin/teku --log-destination=CONSOLE \
   validator-client \

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -18,13 +18,18 @@ fi
 
 
 
-if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]];
-then
+if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]]; then
+    echo "Check connectivity with the web3signer"
+    WEB3SIGNER_STATUS=$(curl -s  http://web3signer.web3signer-prater.dappnode:9000/healthcheck | jq '.status')
+    if [[ "$WEB3SIGNER_STATUS" == '"UP"' ]]; then
     echo "Proceeds to do the voluntary exit of the next keystores:"
     echo "$KEYSTORES_VOLUNTARY_EXIT"
-    exec/opt/teku/bin/teku voluntary-exit --beacon-node-api-endpoint=http://beacon-chain.teku-prater.dappnode:3500 \
+    echo yes | exec /opt/teku/bin/teku voluntary-exit --beacon-node-api-endpoint=http://beacon-chain.teku-prater.dappnode:3500 \
         --validators-external-signer-public-keys=$KEYSTORES_VOLUNTARY_EXIT \
-        --validators-external-signer-url=http://web3signer.web3signer-prater.dappnode:9000
+        --validators-external-signer-url=$WEB3SIGNER_API
+    else
+      echo "The web3signer-prater is not running or the teku package has not access to the web3signer"
+    fi
 fi
 
 


### PR DESCRIPTION
This PR adds the feature of doing an voluntary exit only defining some env vars. The process to do the exit is the next one:

#Voluntary Exit feature

Go to teku-prater package, config tab, advanced options, and fill the next fields:

Type in the var EXIT_VALIDATOR:`I want to exit my validators`
And in the var KEYSTORES_VOLUNTARY_EXIT: the public keystores you want to exit 0x4723984729,0x7979832...