### PR TITLE
Fix warning typos, and fix MEV-Boost config update graffiti limit

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -8,30 +8,32 @@ WEB3SIGNER_API="http://web3signer.web3signer-${NETWORK}.dappnode:9000"
 if [ -n "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" ] && [ "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" == "true" ]; then
   echo "MEVBOOST is enabled"
   MEVBOOST_URL="http://mev-boost.mev-boost-goerli.dappnode:18550"
+  EXTRA_OPTS="--validators-builder-registration-default-enabled --validators-proposer-blinded-blocks-enabled=true ${EXTRA_OPTS}"
   if curl --retry 5 --retry-delay 5 --retry-all-errors "${MEVBOOST_URL}"; then
-    EXTRA_OPTS="--validators-builder-registration-default-enabled ${EXTRA_OPTS}"
-  else
-    echo "MEVBOOST is enabled but ${MEVBOOST_URL} is not reachable"
+    echo "MEVBOOST Göerli is enabled but ${MEVBOOST_URL} is not reachable"
     curl -X POST -G 'http://my.dappnode/notification-send' --data-urlencode 'type=danger' --data-urlencode title="${MEVBOOST_URL} is not available" --data-urlencode 'body=Make sure the mevboost is available and running'
   fi
 fi
 
-
-
 if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]]; then
-    echo "Check connectivity with the web3signer"
-    WEB3SIGNER_STATUS=$(curl -s  http://web3signer.web3signer-prater.dappnode:9000/healthcheck | jq '.status')
-    if [[ "$WEB3SIGNER_STATUS" == '"UP"' ]]; then
+  echo "Checking connectivity with the Prater Web3signer"
+  WEB3SIGNER_STATUS=$(curl -s http://web3signer.web3signer.dappnode:9000/healthcheck | jq '.status')
+  if [[ "$WEB3SIGNER_STATUS" == '"UP"' ]]; then
     echo "Proceeds to do the voluntary exit of the next keystores:"
     echo "$KEYSTORES_VOLUNTARY_EXIT"
-    echo yes | exec /opt/teku/bin/teku voluntary-exit --beacon-node-api-endpoint=http://beacon-chain.teku-prater.dappnode:3500 \
-        --validators-external-signer-public-keys=$KEYSTORES_VOLUNTARY_EXIT \
-        --validators-external-signer-url=$WEB3SIGNER_API
-    else
-      echo "The web3signer-prater is not running or the teku package has not access to the web3signer"
-    fi
+    echo yes | exec /opt/teku/bin/teku voluntary-exit --beacon-node-api-endpoint=http://beacon-chain.teku.dappnode:3500 \
+      --validators-external-signer-public-keys=$KEYSTORES_VOLUNTARY_EXIT \
+      --validators-external-signer-url=$WEB3SIGNER_API
+  else
+    echo "The Prater Web3signer is not running or Teku cannot access the Prater Web3signer"
+  fi
 fi
 
+#Handle Graffiti Character Limit
+oLang=$LANG oLcAll=$LC_ALL
+LANG=C LC_ALL=C 
+graffitiString=${GRAFFITI:0:32}
+LANG=$oLang LC_ALL=$oLcAll
 
 # Teku must start with the current env due to JAVA_HOME var
 exec /opt/teku/bin/teku --log-destination=CONSOLE \
@@ -48,7 +50,7 @@ exec /opt/teku/bin/teku --log-destination=CONSOLE \
   --validator-api-interface=0.0.0.0 \
   --validator-api-port="$VALIDATOR_PORT" \
   --validator-api-host-allowlist=* \
-  --validators-graffiti="${GRAFFITI:0:32}" \
+  --validators-graffiti="${graffitiString}" \
   --validator-api-keystore-file=/cert/teku_client_keystore.p12 \
   --validator-api-keystore-password-file=/cert/teku_keystore_password.txt \
   --validators-proposer-default-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -6,12 +6,12 @@ WEB3SIGNER_API="http://web3signer.web3signer-${NETWORK}.dappnode:9000"
 
 # MEVBOOST: https://docs.teku.consensys.net/en/latest/HowTo/Builder-Network/
 if [ -n "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" ] && [ "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" == "true" ]; then
-  echo "MEVBOOST is enabled"
+  echo "MEV-BOOST is Enabled"
   MEVBOOST_URL="http://mev-boost.mev-boost-goerli.dappnode:18550"
   EXTRA_OPTS="--validators-builder-registration-default-enabled --validators-proposer-blinded-blocks-enabled=true ${EXTRA_OPTS}"
-  if curl --retry 5 --retry-delay 5 --retry-all-errors "${MEVBOOST_URL}"; then
-    echo "MEVBOOST Göerli is enabled but ${MEVBOOST_URL} is not reachable"
-    curl -X POST -G 'http://my.dappnode/notification-send' --data-urlencode 'type=danger' --data-urlencode title="${MEVBOOST_URL} is not available" --data-urlencode 'body=Make sure the mevboost is available and running'
+  if curl --retry 5 --retry-delay 5 --retry-connrefused "${MEVBOOST_URL}"; then
+    echo "MEV-BOOST Göerli/Prater is enabled but ${MEVBOOST_URL} is not reachable"
+    curl -X POST -G 'http://my.dappnode/notification-send' --data-urlencode 'type=danger' --data-urlencode title="${MEVBOOST_URL} is not available" --data-urlencode 'body=Make sure the Göerli/Prater MEV-Boost DNP is available and running'
   fi
 fi
 


### PR DESCRIPTION
- Fix typos and wording in warnings.
- fix MEV-Boost status check (container image installed Curl version is too old to use `--retry-all-errors` argument, in practice this returns an error message in the logs of Teku that MEV-Boost cannot be reached.)  Reordered IF Statements so that MEV-Boost flags are added if global MEV boost value is set to `true`, then Run MEV-Boost status check but with `--retry-all-errors` replaced with `--retry-connrefused` for the Curl  IF statement which checks MEV-Boost package availability if it fails it will return MEV-Boost enabled but package not available and will throw a system error notification to the adminUI and Telegram if configured.  
- fix MEV-Boost config  - explicitly added `--validators-proposer-blinded-blocks-enabled=true` flag which in theory shouldn't be needed as it's implicitly activated when `--validators-builder-registration-default-enabled` is passed. However users have shown error logs related to the blinded blocks flag not being enabled when they have MEV-Boost enabled. 
- update graffiti limit to account for non ASCII characters to prevent restart loop.