### PR TITLE
Fixed validator MEV BOOST params

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -6,15 +6,15 @@ WEB3SIGNER_API="http://web3signer.web3signer-${NETWORK}.dappnode:9000"
 
 # MEVBOOST: https://docs.teku.consensys.net/en/latest/HowTo/Builder-Network/
 if [ -n "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" ] && [ "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" == "true" ]; then
-  echo "MEV-BOOST is enabled"
+  echo "MEV-Boost is enabled"
   MEVBOOST_URL="http://mev-boost.mev-boost-goerli.dappnode:18550"
   EXTRA_OPTS="--validators-builder-registration-default-enabled=true ${EXTRA_OPTS}"
 
   if curl --retry 5 --retry-delay 5 --retry-all-errors "${MEVBOOST_URL}"; then
-    echo "MEVBOOST is enabled and ${MEVBOOST_URL} is reachable"
+    echo "MEV-Boost is enabled and ${MEVBOOST_URL} is reachable"
   else
-    echo "MEVBOOST is enabled but ${MEVBOOST_URL} is not reachable"
-    curl -X POST -G 'http://my.dappnode/notification-send' --data-urlencode 'type=danger' --data-urlencode title="${MEVBOOST_URL} is not available" --data-urlencode 'body=Make sure the mevboost is available and running'
+    echo "MEV-Boost is enabled but ${MEVBOOST_URL} is not reachable"
+    curl -X POST -G 'http://my.dappnode/notification-send' --data-urlencode 'type=danger' --data-urlencode title="${MEVBOOST_URL} is not available" --data-urlencode 'body=Make sure the MEV-Boost Goerli DNP is available and running'
   fi
 fi
 

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -6,16 +6,17 @@ WEB3SIGNER_API="http://web3signer.web3signer-${NETWORK}.dappnode:9000"
 
 # MEVBOOST: https://docs.teku.consensys.net/en/latest/HowTo/Builder-Network/
 if [ -n "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" ] && [ "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" == "true" ]; then
-  echo "MEVBOOST is enabled"
+  echo "MEV-BOOST is enabled"
   MEVBOOST_URL="http://mev-boost.mev-boost-goerli.dappnode:18550"
+  EXTRA_OPTS="--validators-builder-registration-default-enabled=true ${EXTRA_OPTS}"
+
   if curl --retry 5 --retry-delay 5 --retry-all-errors "${MEVBOOST_URL}"; then
-    EXTRA_OPTS="--validators-builder-registration-default-enabled ${EXTRA_OPTS}"
+    echo "MEVBOOST is enabled and ${MEVBOOST_URL} is reachable"
   else
     echo "MEVBOOST is enabled but ${MEVBOOST_URL} is not reachable"
     curl -X POST -G 'http://my.dappnode/notification-send' --data-urlencode 'type=danger' --data-urlencode title="${MEVBOOST_URL} is not available" --data-urlencode 'body=Make sure the mevboost is available and running'
   fi
 fi
-
 
 
 if [[ "$EXIT_VALIDATOR" == "I want to exit my validators" ]]; then


### PR DESCRIPTION
Now the flag `--validators-builder-registration-default-enabled` is set to TRUE even if MEV Boost is not reachable at that moment