### PR TITLE
Add memory managenment java_opt to compose

### DIFF
--- a/beacon-chain/Dockerfile
+++ b/beacon-chain/Dockerfile
@@ -15,7 +15,6 @@ RUN apt update && apt install wget --yes
 RUN mkdir -p /opt/teku/data
 RUN chown -R 1001:1001 /opt/teku/data
 
-ENV JAVA_OPTS="-Xmx5g"
 
 # API port: https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#rest-api-port
 EXPOSE $BEACON_API_PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       P2P_PORT: 9505
       FEE_RECIPIENT_ADDRESS: ""
       EXTRA_OPTS: ""
-      JAVA_OPTS: "-Xmx5g"
+      JAVA_OPTS: "-Xmx6g"
     volumes:
       - "teku-prater-data:/opt/teku/data"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       EXIT_VALIDATOR: ""
       KEYSTORES_VOLUNTARY_EXIT: ""
       FEE_RECIPIENT_ADDRESS: ""
-      JAVA_OPTS: "-Xmx5g"
+      JAVA_OPTS: "-Xmx6g"
     restart: unless-stopped
     image: "validator.teku-prater.dnp.dappnode.eth:0.1.11"
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       P2P_PORT: 9505
       FEE_RECIPIENT_ADDRESS: ""
       EXTRA_OPTS: ""
+      JAVA_OPTS: "-Xmx5g"
     volumes:
       - "teku-prater-data:/opt/teku/data"
     ports:
@@ -34,6 +35,7 @@ services:
       EXIT_VALIDATOR: ""
       KEYSTORES_VOLUNTARY_EXIT: ""
       FEE_RECIPIENT_ADDRESS: ""
+      JAVA_OPTS: "-Xmx5g"
     restart: unless-stopped
     image: "validator.teku-prater.dnp.dappnode.eth:0.1.11"
     security_opt:

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -13,6 +13,5 @@ COPY entrypoint.sh /usr/bin/entrypoint.sh
 
 RUN apt-get update && apt-get install ca-certificates --yes 
 
-ENV JAVA_OPTS="-Xmx5g"
 
 ENTRYPOINT [ "entrypoint.sh" ]


### PR DESCRIPTION
Users should have the option to change Teku's Java Virtual Machine (JVM) memory usage by setting a maximum heap size using the JAVA_OPTS environment variable. 

This PR changes the environment variable from Dockerfile to docker-compose.yml so that it appears in the dnp package's configuration.

Context: https://docs.teku.consensys.net/get-started/manage-memory  

